### PR TITLE
🏷️ Fix deprecated types in `typing`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import typing as t
+from collections import abc
 
 import pytest
 
@@ -26,7 +27,7 @@ def filepath_or_buffer(
     request: FixtureRequest[str],
     filepath: typing.FilePath,
     open_mode: t.Literal["rb", "wb"],
-) -> t.Generator[typing.FilePathOrBuffer, None, None]:
+) -> abc.Generator[typing.FilePathOrBuffer, None, None]:
     match request.param:
         case "buffer":
             if "r" in open_mode:

--- a/tests/test_core_presentation.py
+++ b/tests/test_core_presentation.py
@@ -1,5 +1,5 @@
 import functools
-import typing as t
+from collections import abc
 from unittest import mock
 
 import pptx
@@ -48,7 +48,7 @@ def describe_presentation() -> None:
         assert prs.slides == tuple(map(slide.Slide, prs._prs.slides))
 
     @pytest.fixture()
-    def add_slide_mock() -> t.Generator[mock.Mock, None, None]:
+    def add_slide_mock() -> abc.Generator[mock.Mock, None, None]:
         sld = mock.Mock(spec_set=pptx.slide.Slide)
         with mock.patch("pptx.slide.Slides.add_slide", return_value=sld) as m:
             yield m

--- a/tests/test_core_slide.py
+++ b/tests/test_core_slide.py
@@ -1,5 +1,5 @@
 import copy
-import typing as t
+from collections import abc
 from unittest import mock
 
 import plotly.graph_objects as go
@@ -140,7 +140,7 @@ def describe_slide() -> None:
             slide.update_title()
 
     @pytest.fixture()
-    def fig() -> t.Generator[go.Figure, None, None]:
+    def fig() -> abc.Generator[go.Figure, None, None]:
         with mock.patch("plotly.graph_objects.Figure.to_image", return_value=b""):
             yield go.Figure()
 


### PR DESCRIPTION
- Fix `typing.Generator` to `collections.abc.Generator`