### PR TITLE
✨ Make `get_date_annotation` take `date` of tuple

### DIFF
--- a/src/tlab_pptx/figure.py
+++ b/src/tlab_pptx/figure.py
@@ -70,14 +70,24 @@ def get_default_axis() -> dict[str, t.Any]:
     return dict(ticks="inside", mirror=True, showline=True)
 
 
-def get_date_annotation(date: datetime.date) -> dict[str, t.Any]:
+def get_date_annotation(date: datetime.date | tuple[int, int, int]) -> dict[str, t.Any]:
     """
     Gets a date annotation of a plotly.graph_objects.Figure object for PowerPoint.
+
+    Parameters
+    ----------
+    date : datetime.date | tuple[int, int, int]
+        A date object or compiatible tuple.
 
     Returns
     -------
     dict[str, Any]
         An annotation of date.
+
+    Raises
+    ------
+    ValueError
+        If date is not compiatible with `datetime.date`.
 
     See also
     --------
@@ -101,6 +111,11 @@ def get_date_annotation(date: datetime.date) -> dict[str, t.Any]:
                    'template': '...'}
     })
     """
+    if isinstance(date, tuple):
+        try:
+            date = datetime.date(*date[:3])
+        except (ValueError, TypeError) as err:
+            raise ValueError(f"{date} is not compiatible with `datetime.date`") from err
     return dict(
         text=date.strftime("%Y.%m.%d"),
         x=1.0,

--- a/tests/test_figure.py
+++ b/tests/test_figure.py
@@ -8,12 +8,25 @@ from tlab_pptx import figure
 
 @pytest.mark.parametrize(
     "date",
-    [datetime.date(2022, 1, 1), datetime.date(2023, 12, 31)],
+    [datetime.date(2022, 1, 1), datetime.date(2023, 12, 31), (2022, 1, 1)],
 )
-def test_get_date_annotaion(date: datetime.date) -> None:
+def test_get_date_annotaion(date: datetime.date | tuple[int, int, int]) -> None:
     annotation = figure.get_date_annotation(date)
+    if isinstance(date, tuple):
+        date = datetime.date(*date)
     assert annotation["text"] == date.strftime("%Y.%m.%d")
     assert go.layout.Annotation(annotation)  # TODO: Expect assert not raises ValueError
+
+
+@pytest.mark.parametrize(
+    "date",
+    [(2022, 13, 1), (2022, 1)],
+)
+def test_get_date_annotaion_with_incompiatible_tuple(
+    date: datetime.date | tuple[int, int, int]
+) -> None:
+    with pytest.raises(ValueError):
+        figure.get_date_annotation(date)
 
 
 def test_get_default_layout() -> None:


### PR DESCRIPTION
## Related issues
- `get_date_annotation` takes `date` of tuple #17